### PR TITLE
Update to 0.1.7

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,17 @@
+{% set version = "0.1.7" %}
+
 package:
     name: wcwidth
-    version: "0.1.5"
+    version: {{ version }}
 
 source:
-    fn: wcwidth-0.1.5.tar.gz
-    url: https://pypi.python.org/packages/source/w/wcwidth/wcwidth-0.1.5.tar.gz
-    md5: 2282d853074f2f1f465a3387e524d99b
+    fn: wcwidth-{{ version }}.tar.gz
+    url: https://pypi.io/packages/source/w/wcwidth/wcwidth-{{ version }}.tar.gz
+    sha256: 3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e
 
 build:
     number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
     build:
@@ -24,8 +27,8 @@ test:
 
 about:
     home: https://github.com/jquast/wcwidth
-    license: MIT License
-    summary: 'Measures number of Terminal column cells of wide-character codes'
+    license: MIT
+    summary: 'Measures number of Terminal column cells of wide-character codes.'
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
```
History

0.1.7 2016-07-01
Updated tables to Unicode Specification 9.0.0. (PR #18).

0.1.6 2016-01-08 Production/Stable
LICENSE file now included with distribution.

0.1.5 2015-09-13 Alpha
Bugfix: Resolution of “combining character width” issue, most especially those that previously returned -1 now often (correctly) return 0. resolved by Philip Craig via PR #11.
Deprecated: The module path wcwidth.table_comb is no longer available, it has been superseded by module path wcwidth.table_zero.
```
